### PR TITLE
add native clipPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # VictoryChartNative Changelog
 
+## 1.0.0 (2016-08-22)
+
+- **Moves `react-native-svg` to `peerDependencies`**
+- Adds support for `clipPath`
+
+## 0.2.0 (2016-07-27)
+
+- Adds VictoryCandlestick
+
 ## 0.1.1 (2016-07-19)
 
 - Adds VictoryErrorBar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-## Contributor Covenant Code of Conduct
-
-Please review our [Code of Conduct][code] before contributing.
-
-[code]: https://github.com/FormidableLabs/builder-victory-component/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ Then open `demo/ios/Demo.xcodeproj` and run the app. (Note: `npm start` must run
 ## _IMPORTANT_
 
 This project is in a pre-release state. We're hard at work fixing bugs and improving the API. Be prepared for breaking changes!
+
+## Contributor Covenant Code of Conduct
+
+Please review our [Code of Conduct][code] before contributing.
+
+[code]: https://github.com/FormidableLabs/builder-victory-component/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

--- a/lib/components/helpers/clip-path.js
+++ b/lib/components/helpers/clip-path.js
@@ -6,7 +6,7 @@ export default class extends ClipPath {
   renderClipPath(props, id) {
     return (
       <Defs>
-        <Clip id={id}>
+        <Clip id={`${id}`}>
           <Rect {...props}/>
         </Clip>
       </Defs>

--- a/lib/components/helpers/clip-path.js
+++ b/lib/components/helpers/clip-path.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { ClipPath as Clip, Rect, Defs } from "react-native-svg";
+import ClipPath from "victory-chart/src/components/helpers/clip-path";
+
+export default class extends ClipPath {
+  renderClipPath(props, id) {
+    return (
+      <Defs>
+        <Clip id={id}>
+          <Rect {...props}/>
+        </Clip>
+      </Defs>
+    );
+  }
+}

--- a/lib/components/victory-area/victory-area.js
+++ b/lib/components/victory-area/victory-area.js
@@ -4,12 +4,14 @@ import { G } from "react-native-svg";
 import { VictoryLabel, VictoryContainer } from "victory-core-native";
 import { VictoryArea } from "victory-chart/src";
 import Area from "./area";
+import ClipPath from "../helpers/clip-path";
 
 export default class extends VictoryArea {
   static defaultProps = {
     ...VictoryArea.defaultProps,
     dataComponent: <Area/>,
     labelComponent: <VictoryLabel/>,
+    clipPathComponent: <ClipPath/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width

--- a/lib/components/victory-bar/victory-bar.js
+++ b/lib/components/victory-bar/victory-bar.js
@@ -4,12 +4,15 @@ import { G } from "react-native-svg";
 import { VictoryLabel, VictoryContainer } from "victory-core-native";
 import { VictoryBar } from "victory-chart/src";
 import Bar from "./bar";
+import ClipPath from "../helpers/clip-path";
+
 
 export default class extends VictoryBar {
   static defaultProps = {
     ...VictoryBar.defaultProps,
     dataComponent: <Bar/>,
     labelComponent: <VictoryLabel/>,
+    clipPathComponent: <ClipPath/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width

--- a/lib/components/victory-line/victory-line.js
+++ b/lib/components/victory-line/victory-line.js
@@ -3,6 +3,7 @@ import { Dimensions } from "react-native";
 import { G } from "react-native-svg";
 import { VictoryLine } from "victory-chart/src";
 import LineSegment from "./line-segment";
+import ClipPath from "../helpers/clip-path";
 import { VictoryLabel, VictoryContainer } from "victory-core-native";
 
 export default class extends VictoryLine {
@@ -10,6 +11,7 @@ export default class extends VictoryLine {
     ...VictoryLine.defaultProps,
     dataComponent: <LineSegment/>,
     labelComponent: <VictoryLabel/>,
+    clipPathComponent: <ClipPath/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <G/>,
     width: Dimensions.get("window").width

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victory-chart-native",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Chart Component for Victory",
   "main": "lib/index.js",
   "files": [
@@ -33,17 +33,22 @@
     "eslint-config-defaults": "^10.0.0-1",
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-react": "^3.12.0",
+    "lodash.random": "^3.2.0",
+    "lodash.range": "^3.2.0",
     "mocha": "^3.0.1",
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.0",
-    "react-native": ">=0.29.0",
+    "react-native": "~0.31.0",
     "react-native-mock": "^0.2.5",
+    "react-native-svg": "^4.1.0",
     "react-native-svg-mock": "^1.0.2"
+  },
+  "peerDependencies": {
+    "react-native-svg": "~4.0.0"
   },
   "dependencies": {
     "react": "^15.3.0",
-    "react-native-svg": "^3.1.1",
-    "victory-chart": "^10.1.0",
-    "victory-core-native": "^0.2.1"
+    "victory-chart": "^11.0.0",
+    "victory-core-native": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-native-svg-mock": "^1.0.2"
   },
   "peerDependencies": {
-    "react-native-svg": "~4.0.0"
+    "react-native-svg": "^4.1.0"
   },
   "dependencies": {
     "react": "^15.3.0",


### PR DESCRIPTION
**depends on https://github.com/FormidableLabs/victory-chart/pull/352**

Fixes the bug addressed in https://github.com/FormidableLabs/victory-chart-native/pull/14

This PR adds a native `ClipPath` component to all the component types that need it. 
